### PR TITLE
ulogin:  Enable DHCP in NAT mode.

### DIFF
--- a/test_scripts/python/ulogin.py
+++ b/test_scripts/python/ulogin.py
@@ -17,6 +17,13 @@
 #   --key24 12345678 --key5 12345678 --encryption24 psk2 --encryption5 psk2 --action cfg \
 #   --network24 wan --network5 wan
 
+# Configure 2 ssid setup with psk2 in NAT/Routed mode.
+# Use local cert downloaded from a remote ucentralgw
+# ./ulogin.py --serno c4411ef53f23 --cert ~/lab-ctlr-ucentral-cert.pem \
+#   --ucentral_host test-controller-1 --ssid24 Default-SSID-2g --ssid5 Default-SSID-5gl \
+#   --key24 12345678 --key5 12345678 --encryption24 psk2 --encryption5 psk2 --action cfg \
+#   --network24 lan --network5 lan
+
 
 import json
 from urllib.parse import urlparse
@@ -235,7 +242,12 @@ def cfg_device(args):
    "mode": "lan",
    "cfg": {
     "proto": "static",
-    "ipaddr": "192.168.1.1"
+    "ipaddr": "192.168.1.1",
+    "dhcp": {
+     "start": 10,
+     "limit": 240,
+     "leasetime": "6h"
+    }
    }
   }
  ]


### PR DESCRIPTION
This lets NAT mode work as expected.

Signed-off-by: Ben Greear <greearb@candelatech.com>