### PR TITLE
[WIFI-3202] Fix: upload directory in Docker

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -171,7 +171,7 @@ configProperties:
   ucentral.fileuploader.host.0.port: 16003
   ucentral.fileuploader.host.0.cert: $UCENTRALGW_ROOT/certs/restapi-cert.pem
   ucentral.fileuploader.host.0.key: $UCENTRALGW_ROOT/certs/restapi-key.pem
-  ucentral.fileuploader.path: $UCENTRALGW_ROOT/uploads
+  ucentral.fileuploader.path: $UCENTRALGW_ROOT/persist/uploads
   ucentral.fileuploader.maxsize: 10000
   # Auto provisioning
   ucentral.autoprovisioning: "true"


### PR DESCRIPTION
- creates upload directory on Docker container startup
- changes path to upload directory path in Helm installation to be present in persistent volume

Signed-off-by: Dmitry Dunaev <dmitry@opsfleet.com>