### PR TITLE
Revert "[WIFI-5420] Add: helm sysctl for tcp keepalive"

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -112,13 +112,6 @@ resources: {}
 
 securityContext:
   fsGroup: 101
-  sysctls:
-  - name: net.ipv4.tcp_keepalive_intvl
-    value: "5"
-  - name: net.ipv4.tcp_keepalive_probes
-    value: "2"
-  - name: net.ipv4.tcp_keepalive_time
-    value: "45"
 
 nodeSelector: {}
 


### PR DESCRIPTION
Reverting changes due to issues in Kubernetes deployment.
Reverts Telecominfraproject/wlan-cloud-ucentralgw#61