### PR TITLE
[WIFI-5721] Create docker-compose for OWLS

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,7 @@ if [[ "$TEMPLATE_CONFIG" = 'true' && ! -f "$OWGW_CONFIG"/owgw.properties ]]; the
   SYSTEM_URI_PRIVATE=${SYSTEM_URI_PRIVATE:-"https://localhost:17002"} \
   SYSTEM_URI_PUBLIC=${SYSTEM_URI_PUBLIC:-"https://localhost:16002"} \
   SYSTEM_URI_UI=${SYSTEM_URI_UI:-"http://localhost"} \
+  SIMULATORID=${SIMULATORID:-""} \
   RTTY_ENABLED=${RTTY_ENABLED:-"false"} \
   RTTY_SERVER=${RTTY_SERVER:-"localhost"} \
   RTTY_PORT=${RTTY_PORT:-"5912"} \

--- a/owgw.properties.tmpl
+++ b/owgw.properties.tmpl
@@ -76,6 +76,7 @@ openwifi.devicetypes.1 = SWITCH:edgecore_ecs4100-12ph
 openwifi.devicetypes.2 = IOT:esp32
 oui.download.uri = https://linuxnet.ca/ieee/oui.txt
 firmware.autoupdate.policy.default = auto
+simulatorid = ${SIMULATORID}
 
 #
 # rtty


### PR DESCRIPTION
This change is needed since the gateway now only accepts specified client certificates for load simulation https://telecominfraproject.atlassian.net/browse/WIFI-6014.