### PR TITLE
WIFI-7962: Add logdump call support

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -393,6 +393,39 @@ The device should answer with teh above message. The `error` value should be int
 - 1 : the command will be performed in the future and `when` shows that time. The `resultCode` and `resultText` dod not contain anything relevant.
 - 2 : the command cannot be performed as indicated. `resultCode` and `resultText` may contain some indication as to why.
 
+#### Controller wants the device to perform a tech support dump
+Controller sends this command when it needs the device to perform a tech support dump (logdump).
+```
+{    "jsonrpc" : "2.0" ,
+     "method" : "trace" ,
+     "params" : {
+        "serial" : <serial number> ,
+        "when" : Optional - <UTC time when to start, 0 meaning immediately, this is a suggestion>,
+        "uri" : <complete URI where to upload the trace. This URI will be available for 30 minutes following a trace request start>
+     },
+     "id" : <some number>
+}
+```
+
+The device should answer:
+```
+{   "jsonrpc" : "2.0" , 
+    "result" : {
+       "serial" : <serial number> ,
+       "status" : {
+          "error" : 0 or an error number,
+          "text" : <description of the error or success>,
+          "when" : <time when this will be performed as UTC seconds>
+       }
+    },
+    "id" : <same number>
+}
+```
+
+###### 'uri'
+The `uri` for file upload is available for 30 minutes following the start of the capture. Once the file has been
+uploaded or the timeout occurs, the upload will be rejected.
+
 #### Controller wants the device to perform a trace
 Controller sends this command when it needs the device to perform a trace (i.e. tcpdump).
 ```

--- a/openapi/owgw.yaml
+++ b/openapi/owgw.yaml
@@ -2121,6 +2121,32 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
+  /device/{serialNumber}/logdump:
+    post:
+      tags:
+        - Commands
+      summary: Launch a tech support dump for a device.
+      operationId: logDumpRequest
+      parameters:
+        - in: path
+          name: serialNumber
+          schema:
+            type: string
+          required: true
+      requestBody:
+        description: Command details
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogDumpRequest'
+      responses:
+        200:
+          $ref: '#/components/schemas/CommandInfo'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+
   /device/{serialNumber}/wifiscan:
     post:
       tags:

--- a/src/RESTAPI/RESTAPI_RPC.cpp
+++ b/src/RESTAPI/RESTAPI_RPC.cpp
@@ -89,7 +89,8 @@ namespace OpenWifi::RESTAPI_RPC {
 						Cmd.Completed = OpenWifi::Now();
 						Cmd.executionTime = rpc_execution_time.count();
 
-						if (Cmd.ErrorCode && Cmd.Command == uCentralProtocol::TRACE) {
+						if (Cmd.ErrorCode && (Cmd.Command == uCentralProtocol::TRACE
+						    || Cmd.Command == uCentralProtocol::LOGDUMP)) {
 							Cmd.WaitingForFile = 0;
 							Cmd.AttachDate = Cmd.AttachSize = 0;
 							Cmd.AttachType = "";

--- a/src/RESTAPI/RESTAPI_device_commandHandler.h
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.h
@@ -39,6 +39,7 @@ namespace OpenWifi {
 		void Factory();
 		void LEDs();
 		void Trace();
+		void LogDump();
 		void MakeRequest();
 		void WifiScan();
 		void EventQueue();

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -206,6 +206,7 @@ namespace OpenWifi::RESTAPI::Protocol {
 	static const char * FACTORY = "factory";
 	static const char * LEDS = "leds";
 	static const char * TRACE = "trace";
+	static const char * LOGDUMP = "logdump";
 	static const char * REQUEST = "request";
 	static const char * WIFISCAN = "wifiscan";
 	static const char * EVENTQUEUE = "eventqueue";
@@ -235,6 +236,7 @@ namespace OpenWifi::RESTAPI::Protocol {
 	static const char * STATE = "state";
 	static const char * HEALTHCHECK = "healthcheck";
 	static const char * PCAP_FILE_TYPE = "pcap";
+	static const char * TAR_GZ_FILE_TYPE = "tar.gz";
 	static const char * DURATION = "duration";
 	static const char * NUMBEROFPACKETS = "numberOfPackets";
 	static const char * FILTER = "filter";
@@ -385,6 +387,7 @@ namespace OpenWifi::uCentralProtocol {
     static const char *NETWORK = "network";
     static const char *INTERFACE = "interface";
     static const char *TRACE = "trace";
+    static const char *LOGDUMP = "logdump";
     static const char *WIFISCAN = "wifiscan";
     static const char *TYPES = "types";
     static const char *EVENT = "event";


### PR DESCRIPTION
This adds support for the logdump call, which provides the Tech support
dump feature

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>