### PR TITLE
WIFI-12200-The-default-OpenWifi-SSID-Dev

### DIFF
--- a/src/CentralConfig.cpp
+++ b/src/CentralConfig.cpp
@@ -37,23 +37,6 @@ R"lit(
         "ssh",
         "lldp",
         "dhcp-snooping"
-      ],
-      "ssids": [
-        {
-          "bss-mode": "ap",
-          "encryption": {
-            "ieee80211w": "optional",
-            "key": "OpenWifi",
-            "proto": "psk2"
-          },
-          "name": "OpenWifi",
-          "services": [
-            "wifi-frames"
-          ],
-          "wifi-bands": [
-           "2G","5G"
-          ]
-        }
       ]
     },
     {


### PR DESCRIPTION
Changes done to delete the default SSID "OpenWifi"