### PR TITLE
OLS-56: fix: replaced incorrect case conversion for device type

### DIFF
--- a/src/framework/ConfigurationValidator.h
+++ b/src/framework/ConfigurationValidator.h
@@ -31,7 +31,7 @@ namespace OpenWifi {
 		void reinitialize(Poco::Util::Application &self) override;
 
 		inline static ConfigurationType GetType(const std::string &type) {
-			std::string Type = Poco::toUpper(type);
+                       std::string Type = Poco::toLower(type);
 			if (Type == Platforms::AP)
 				return ConfigurationType::AP;
 			if (Type == Platforms::SWITCH)


### PR DESCRIPTION
# Description

OLS schema is not parsed properly on GW side. More details on the issue in:
https://telecominfraproject.atlassian.net/browse/OLS-56

# Summary of changes:
- Replaced incorrect case conversion for device type.