### PR TITLE
WIP: Experimental k8s config (DO NOT MERGE)

### DIFF
--- a/src/AP_WS_Reactor_Pool.h
+++ b/src/AP_WS_Reactor_Pool.h
@@ -20,7 +20,8 @@ namespace OpenWifi {
 	class AP_WS_ReactorThreadPool {
 	  public:
 		explicit AP_WS_ReactorThreadPool(Poco::Logger &Logger) : Logger_(Logger) {
-			NumberOfThreads_ = Poco::Environment::processorCount() * 4;
+			int CPUCount = (int)MicroServiceConfigGetInt("openwifi.system.cpus", Poco::Environment::processorCount());
+			NumberOfThreads_ = CPUCount * 4;
 			if (NumberOfThreads_ == 0)
 				NumberOfThreads_ = 8;
 			NumberOfThreads_ = std::min(NumberOfThreads_, (std::uint64_t) 128);

--- a/src/GenericScheduler.h
+++ b/src/GenericScheduler.h
@@ -26,7 +26,7 @@ namespace OpenWifi {
 	  private:
 		GenericScheduler() noexcept
 			: SubSystemServer("Scheduler", "SCHEDULER", "scheduler"),
-			  Scheduler_(Poco::Environment::processorCount()*2) {
+			  Scheduler_(((int)std::stoi(Poco::Environment::get("GENERIC_SCHEDULER_CORES", std::to_string(Poco::Environment::processorCount()))))*2) {
 
 		}
 		Bosma::Scheduler	Scheduler_;


### PR DESCRIPTION
WIP: Exeprimental K8S config

# Description
 Configuration options for CPU resources for OWGW.

# Summary of changes:
- Modified code to use env vat to specify number of CPUs for generic scheduler. If not set, system value is taken.
- Modified code to use configuration parameter to specify number of CPUs. If not set, system value is taken.

