### PR TITLE
fix: modified code to use final as default for fingerprint mode

### DIFF
--- a/src/framework/ConfigurationValidator.cpp
+++ b/src/framework/ConfigurationValidator.cpp
@@ -3769,7 +3769,7 @@ static std::string DefaultAPSchema = R"foo(
                         "final",
                         "raw-data"
                     ],
-                    "default": "always"
+                    "default": "final"
                 },
                 "minimum-age": {
                     "description": "The minimum age a fingerprint must have before it is reported.",


### PR DESCRIPTION
https://telecominfraproject.atlassian.net/browse/WIFI-431

Summary of changes:
- Modified code to use `final` as default value for fingerprint mode.