### PR TITLE
WIFI-13597: fix: modified kafka manager to use poll in producer

### DIFF
--- a/src/framework/KafkaManager.cpp
+++ b/src/framework/KafkaManager.cpp
@@ -107,7 +107,7 @@ namespace OpenWifi {
 					NewMessage.partition(0);
 					NewMessage.payload(Msg->Payload());
 					Producer.produce(NewMessage);
-					Producer.flush();
+					Producer.poll((std::chrono::milliseconds) 0);
 				}
 			} catch (const cppkafka::HandleException &E) {
 				poco_warning(Logger_,
@@ -116,6 +116,10 @@ namespace OpenWifi {
 				Logger_.log(E);
 			} catch (...) {
 				poco_error(Logger_, "std::exception");
+			}
+			if (Queue_.size() == 0) {
+				// message queue is empty, flush all previously sent messages
+				Producer.flush();
 			}
 			Note = Queue_.waitDequeueNotification();
 		}


### PR DESCRIPTION
# Description

During latest experiments with large number of APs, we narrowed down that memory is consumed by Kafka internal queue on GW (producer). And with large number of messages producer cannot keep up with emptying this queue.
One noticeable suspect was identified in `flush()` call [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/src/framework/KafkaManager.cpp#L110)
Looks like, flushing on every message slows down producer to 100 messages per second.

The solution was to use `poll()` to allow for faster message transmission in peak times.

Related Jira: https://telecominfraproject.atlassian.net/browse/WIFI-13597

# Summary of changes:
- Modified code in KafkaManager to use poll instead of flush for every messages sent. flush is used only on empty internal notification queue in idle times.