### PR TITLE
WIFI-14019: fix: relay errors from ap nos configuration only when strict mode is enabled

### DIFF
--- a/src/RESTAPI/RESTAPI_RPC.cpp
+++ b/src/RESTAPI/RESTAPI_RPC.cpp
@@ -26,7 +26,7 @@ namespace OpenWifi::RESTAPI_RPC {
 			Poco::JSON::Object RetObj;
 			Cmd.to_json(RetObj);
 			if (Handler != nullptr)
-				if (Cmd.ErrorCode){
+				if (Handler->GetBoolParameter("strict", false) && Cmd.ErrorCode){
 					return Handler->ReturnObject(RetObj, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
 				}
 				return Handler->ReturnObject(RetObj);
@@ -171,7 +171,7 @@ namespace OpenWifi::RESTAPI_RPC {
 			}
 
 			// If the command fails on the device we should show it as failed and not return 200 OK
-			if (Cmd.ErrorCode) {
+			if (Handler->GetBoolParameter("strict", false) && Cmd.ErrorCode) {
 				Logger.information(fmt::format(
 				"Command failed with error on device: {}  Reason: {}.",
 				Cmd.ErrorCode, Cmd.ErrorText));


### PR DESCRIPTION
# Description

More details are in:
https://telecominfraproject.atlassian.net/browse/WIFI-14019

# Summary of changes:
- Modified code to only relay errors from AP NOS configuration update only when strict mode is enabled.

NOTE: AP NOS is capable of modifying config thus fixing invalid configs (in some cases) and applying resulting configuration. Warning messages are produced, but error code is being sent back as error/failed.

