### PR TITLE
OLS-246: feat: add cable diagnostics command

### DIFF
--- a/src/RESTAPI/RESTAPI_device_commandHandler.cpp
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.cpp
@@ -169,6 +169,7 @@ namespace OpenWifi {
 		{APCommands::Commands::script, false, true, &RESTAPI_device_commandHandler::Script, 60000ms},
 		{APCommands::Commands::powercycle, false, true, &RESTAPI_device_commandHandler::PowerCycle, 60000ms},
 		{APCommands::Commands::fixedconfig, false, true, &RESTAPI_device_commandHandler::FixedConfig, 120000ms},
+		{APCommands::Commands::cablediagnostics, false, true, &RESTAPI_device_commandHandler::CableDiagnostics, 120000ms},
 
 	};
 
@@ -1584,6 +1585,47 @@ namespace OpenWifi {
 
 		// send fixedconfig command to device and return status
 		return RESTAPI_RPC::WaitForCommand(CMD_RPC, APCommands::Commands::fixedconfig, false, Cmd,
+										   *ParsedBody_, *Request, *Response, timeout, nullptr, this,
+										   Logger_);
+	}
+
+	void RESTAPI_device_commandHandler::CableDiagnostics(
+		const std::string &CMD_UUID, uint64_t CMD_RPC,
+		[[maybe_unused]] std::chrono::milliseconds timeout,
+		[[maybe_unused]] const GWObjects::DeviceRestrictions &Restrictions) {
+
+		if(UserInfo_.userinfo.userRole != SecurityObjects::ROOT &&
+			UserInfo_.userinfo.userRole != SecurityObjects::ADMIN) {
+			CallCanceled("CABLEDIAGNOSTICS", CMD_UUID, CMD_RPC, RESTAPI::Errors::ACCESS_DENIED);
+			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
+		}
+
+		poco_debug(Logger_, fmt::format("CABLEDIAGNOSTICS({},{}): TID={} user={} serial={}", CMD_UUID,
+										CMD_RPC, TransactionId_, Requester(), SerialNumber_));
+
+		if(IsDeviceSimulated(SerialNumber_)) {
+			CallCanceled("CABLEDIAGNOSTICS", CMD_UUID, CMD_RPC, RESTAPI::Errors::SimulatedDeviceNotSupported);
+			return BadRequest(RESTAPI::Errors::SimulatedDeviceNotSupported);
+		}
+
+		GWObjects::CableDiagnostics	PR;
+		if(!PR.from_json(ParsedBody_)) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters);
+		}
+
+		GWObjects::CommandDetails Cmd;
+		Cmd.SerialNumber = SerialNumber_;
+		Cmd.SubmittedBy = Requester();
+		Cmd.UUID = CMD_UUID;
+		Cmd.Command = uCentralProtocol::CABLEDIAGNOSTICS;
+		std::ostringstream os;
+		ParsedBody_->stringify(os);
+		Cmd.Details = os.str();
+		Cmd.RunAt = PR.when;
+		Cmd.ErrorCode = 0;
+		Cmd.WaitingForFile = 0;
+
+		return RESTAPI_RPC::WaitForCommand(CMD_RPC, APCommands::Commands::cablediagnostics, false, Cmd,
 										   *ParsedBody_, *Request, *Response, timeout, nullptr, this,
 										   Logger_);
 	}

--- a/src/RESTAPI/RESTAPI_device_commandHandler.h
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.h
@@ -72,6 +72,8 @@ namespace OpenWifi {
 					  const GWObjects::DeviceRestrictions &R);
 		void FixedConfig(const std::string &UUID, uint64_t RPC, std::chrono::milliseconds timeout,
 					  const GWObjects::DeviceRestrictions &R);
+		void CableDiagnostics(const std::string &UUID, uint64_t RPC, std::chrono::milliseconds timeout,
+					  const GWObjects::DeviceRestrictions &R);
 
 		static auto PathName() {
 			return std::list<std::string>{"/api/v1/device/{serialNumber}/{command}"};

--- a/src/RESTObjects/RESTAPI_GWobjects.cpp
+++ b/src/RESTObjects/RESTAPI_GWobjects.cpp
@@ -808,4 +808,15 @@ namespace OpenWifi::GWObjects {
 		}
 		return false;
 	}
+
+	bool CableDiagnostics::from_json(const Poco::JSON::Object::Ptr &Obj) {
+		try {
+			field_from_json(Obj, "serial", serialNumber);
+			field_from_json(Obj, "when", when);
+			field_from_json(Obj, "ports", ports);
+			return true;
+		} catch (const Poco::Exception &E) {
+		}
+		return false;
+	}
 } // namespace OpenWifi::GWObjects

--- a/src/RESTObjects/RESTAPI_GWobjects.h
+++ b/src/RESTObjects/RESTAPI_GWobjects.h
@@ -540,4 +540,11 @@ namespace OpenWifi::GWObjects {
 
 		bool from_json(const Poco::JSON::Object::Ptr &Obj);
 	};
+	struct CableDiagnostics {
+		std::string 	serialNumber;
+		std::uint64_t 	when;
+		std::vector<std::string> ports;
+
+		bool from_json(const Poco::JSON::Object::Ptr &Obj);
+	};
 } // namespace OpenWifi::GWObjects

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -582,6 +582,7 @@ namespace OpenWifi::RESTAPI::Protocol {
 	static const char *BANDWIDTH = "bandwidth";
 
 	static const char *FIXEDCONFIG = "fixedconfig";
+	static const char *CABLEDIAGNOSTICS = "cablediagnostics";
 } // namespace OpenWifi::RESTAPI::Protocol
 
 namespace OpenWifi::uCentralProtocol {
@@ -695,6 +696,7 @@ namespace OpenWifi::uCentralProtocol {
 	static const char *ACTIONS = "actions";
 
 	static const char *FIXEDCONFIG = "fixedconfig";
+	static const char *CABLEDIAGNOSTICS = "cablediagnostics";
 
 } // namespace OpenWifi::uCentralProtocol
 
@@ -793,6 +795,7 @@ namespace OpenWifi::APCommands {
 		transfer,
 		powercycle,
 		fixedconfig,
+		cablediagnostics,
 		unknown
 	};
 
@@ -808,7 +811,7 @@ namespace OpenWifi::APCommands {
 		RESTAPI::Protocol::PING,		 RESTAPI::Protocol::SCRIPT,
 		RESTAPI::Protocol::RRM,		 	 RESTAPI::Protocol::CERTUPDATE,
 		RESTAPI::Protocol::TRANSFER,	 RESTAPI::Protocol::POWERCYCLE,
-		RESTAPI::Protocol::FIXEDCONFIG
+		RESTAPI::Protocol::FIXEDCONFIG,  RESTAPI::Protocol::CABLEDIAGNOSTICS
 	};
 
 	inline const char *to_string(Commands Cmd) { return uCentralAPCommands[(uint8_t)Cmd]; }


### PR DESCRIPTION
# Description
Switch requires cable diagnostics command.
Details are in: https://telecominfraproject.atlassian.net/browse/OLS-246

# Summary of changes
- Added cable diagnostics command.

NOTE: Using AP Commands framework to implement this command. In future switch commands might be separated from AP commands.

NOTE: This is cherry-pick merge.