### PR TITLE
WIFI-14140: fix: sync-ed up ucentral schema with code - added missing code

### DIFF
--- a/src/framework/ConfigurationValidator.cpp
+++ b/src/framework/ConfigurationValidator.cpp
@@ -2411,11 +2411,18 @@ static std::string DefaultAPSchema = R"foo(
                     "$ref": "#/$defs/interface.ssid.encryption"
                 },
                 "multi-psk": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/interface.ssid.multi-psk"
-                    }
-                },
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/interface.ssid.multi-psk"
+                            }
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+		},
                 "rrm": {
                     "$ref": "#/$defs/interface.ssid.rrm"
                 },


### PR DESCRIPTION
# Description
Added missing code that was not present in https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/pull/376
https://telecominfraproject.atlassian.net/browse/WIFI-14140

# Summary of changes:
- Synchronized built-in schema in configuration validation code with ucentral schema. Added missing code.

Followup PR to https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/pull/376