### PR TITLE
OLS-246: feat: add cable diagnostics command

### DIFF
--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -582,7 +582,7 @@ namespace OpenWifi::RESTAPI::Protocol {
 	static const char *BANDWIDTH = "bandwidth";
 
 	static const char *FIXEDCONFIG = "fixedconfig";
-	static const char *CABLEDIAGNOSTICS = "cablediagnostics";
+	static const char *CABLEDIAGNOSTICS = "cable-diagnostics";
 } // namespace OpenWifi::RESTAPI::Protocol
 
 namespace OpenWifi::uCentralProtocol {
@@ -696,7 +696,7 @@ namespace OpenWifi::uCentralProtocol {
 	static const char *ACTIONS = "actions";
 
 	static const char *FIXEDCONFIG = "fixedconfig";
-	static const char *CABLEDIAGNOSTICS = "cablediagnostics";
+	static const char *CABLEDIAGNOSTICS = "cable-diagnostics";
 
 } // namespace OpenWifi::uCentralProtocol
 


### PR DESCRIPTION
# Description
Code needs to be modified to match OLS spec for the command.
https://telecominfraproject.atlassian.net/browse/OLS-246

# Summary of changes:
- Modified code to match spec, ie. command is `cable-diagnostics`.