### PR TITLE
WIFI-14165: Fix wrong port in openapi.yaml

### DIFF
--- a/openapi/owgw.yaml
+++ b/openapi/owgw.yaml
@@ -12,7 +12,7 @@ info:
     url: https://www.ucentral.info/support
 
 servers:
-  - url: 'https://localhost:16001/api/v1'
+  - url: 'https://localhost:16002/api/v1'
 
 security:
   - bearerAuth: []


### PR DESCRIPTION
# Description

Cherry-pick.
Incorrect port was used in old documentation here: https://openwifi.tip.build/developer-resources/api/gateway-service#device-serialnumber-reboot

# Summary of changes
- Modified YAML to use proper port.