### PR TITLE
WIFI-14134: fix: file upload status

### DIFF
--- a/src/RESTAPI/RESTAPI_file.cpp
+++ b/src/RESTAPI/RESTAPI_file.cpp
@@ -22,9 +22,16 @@ namespace OpenWifi {
 
 		std::string FileType;
 		std::string FileContent;
-		if (!StorageService()->GetAttachedFileContent(UUID, SerialNumber, FileContent, FileType) || FileContent.empty()) {
+		int WaitingForFile = 0;
+		if (!StorageService()->GetAttachedFileContent(UUID, SerialNumber, FileContent, FileType, WaitingForFile) && !WaitingForFile) {
 			return NotFound();
 		}
+		else if (WaitingForFile)
+		{
+			// waiting for file to be uploaded, return Accepted
+			return Accepted();
+		}
+
 		if (FileType == "pcap") {
 			SendFileContent(FileContent, "application/vnd.tcpdump.pcap", UUID + ".pcap");
 		}

--- a/src/StorageService.h
+++ b/src/StorageService.h
@@ -243,7 +243,7 @@ namespace OpenWifi {
 									 const std::string &Type);
 		bool CancelWaitFile(std::string &UUID, std::string &ErrorText);
 		bool GetAttachedFileContent(std::string &UUID, const std::string &SerialNumber,
-									std::string &FileContent, std::string &Type);
+									std::string &FileContent, std::string &Type, int& WaitingForFile);
 		bool RemoveAttachedFile(std::string &UUID);
 		bool SetCommandResult(std::string &UUID, std::string &Result);
 		bool GetNewestCommands(std::string &SerialNumber, uint64_t HowMany,

--- a/src/framework/RESTAPI_Handler.h
+++ b/src/framework/RESTAPI_Handler.h
@@ -431,6 +431,11 @@ namespace OpenWifi {
 			}
 		}
 
+		inline void Accepted() {
+			PrepareResponse(Poco::Net::HTTPResponse::HTTP_ACCEPTED);
+			Response->send();
+		}
+
 		inline void SendCompressedTarFile(const std::string &FileName, const std::string &Content) {
 			Response->setStatus(Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK);
 			SetCommonHeaders();


### PR DESCRIPTION
# Description
`Not found` is returned as status in case of large `pcap` files being uploaded (not finished). This cause failure of `pcap` file retrieval.
`Accepted` should be used in such cases.
More details are in:
https://telecominfraproject.atlassian.net/browse/WIFI-14134

# Summary of changes:
- Modified code to return 202 in case of file pening upload.