### PR TITLE
OSL-380: fix: modified code for file upload transactions

### DIFF
--- a/src/storage/storage_command.cpp
+++ b/src/storage/storage_command.cpp
@@ -644,8 +644,6 @@ namespace OpenWifi {
 			uint64_t Size = FileContent.str().size();
 
 			Poco::Data::Session Sess = Pool_->get();
-			Sess.begin();
-			Poco::Data::Statement Statement(Sess);
 
 			if (Size < FileUploader()->MaxSize()) {
 
@@ -668,9 +666,10 @@ namespace OpenWifi {
 			} else {
 				poco_warning(Logger(), fmt::format("File {} is too large.", UUID));
 			}
-			Sess.commit();
 
 			// update CommandList here to ensure that file us uploaded
+                        Sess.begin();
+                        Poco::Data::Statement Statement(Sess);
 			std::string StatementStr;
 			StatementStr =
 				"UPDATE CommandList SET WaitingForFile=?, AttachDate=?, AttachSize=? WHERE UUID=?";


### PR DESCRIPTION
# Description
Transaction being()/commit() sequence needed re-work.
More details in: https://telecominfraproject.atlassian.net/browse/OLS-380

# Summary of changes:
- Modified code to have two distinct transaction in storage file upload.