### PR TITLE
WIFI-14349-plat_cache.json-isnt-being-read-correctly-and-can-result-in-huge-memory-ussages-under-very-specific-situations

### DIFF
--- a/src/CapabilitiesCache.h
+++ b/src/CapabilitiesCache.h
@@ -111,7 +111,7 @@ namespace OpenWifi {
 				i >> cache;
 
 				for (const auto &[Type, Platform] : cache.items()) {
-					Platforms_[Type] = Poco::toLower(to_string(Platform));
+					Platforms_[Type] = Poco::toLower(Platform.get<std::string>());
 				}
 			} catch (...) {
 			}


### PR DESCRIPTION
# Description
`plat_cache.json` not being read correctly and can result in larg memory usage.
Details in:
https://telecominfraproject.atlassian.net/browse/WIFI-14349

# Summary of changes:
- Resolved an issue where a string field was being read as JSON, causing the output to be incorrectly surrounded by quotation marks.
