### PR TITLE
Typo in FindMySQL.cmake

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -104,7 +104,7 @@ endif()
 
 set(MYSQL_VERSION ${PC_MYSQL_VERSION})
 
-find_package_handle_standard_args(MYSQL
+find_package_handle_standard_args(MySQL
   FOUND_VAR MYSQL_FOUND
   REQUIRED_VARS
 	MYSQL_INCLUDE_DIR


### PR DESCRIPTION
CMake Warning (dev) at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:438 (message): The package name passed to find_package_handle_standard_args (MYSQL) does not match the name of the calling package (MySQL). This can lead to problems in calling code that expects find_package result variables (e.g., _FOUND) to follow a certain pattern.
Call Stack (most recent call first):
cmake/FindMySQL.cmake:107 (find_package_handle_standard_args) CMakeLists.txt:66 (find_package)
This warning is for project developers. Use -Wno-dev to suppress it.