### PR TITLE
WIFI-14499: fix deadlock

### DIFF
--- a/src/AP_WS_Connection.cpp
+++ b/src/AP_WS_Connection.cpp
@@ -651,17 +651,10 @@ namespace OpenWifi {
 				} break;
 
 				case Poco::Net::WebSocket::FRAME_OP_TEXT: {
-					if (SerialNumber_ == "e046ee9fed1f") {
-						// Temporary hack for Galgus device
-						poco_information(Logger_,
-							fmt::format("FRAME({}): Frame received (length={}, flags={}). Msg={}",
-										CId_, IncomingSize, flags, IncomingFrame.begin()));
-					}
-					else{
-						poco_trace(Logger_,
-							fmt::format("FRAME({}): Frame received (length={}, flags={}). Msg={}",
-										CId_, IncomingSize, flags, IncomingFrame.begin()));
-					}
+					poco_trace(Logger_,
+						fmt::format("FRAME({}): Frame received (length={}, flags={}). Msg={}",
+									CId_, IncomingSize, flags, IncomingFrame.begin()));
+
 					
 					Poco::JSON::Parser parser;
 					auto ParsedMessage = parser.parse(IncomingFrame.begin());
@@ -702,12 +695,6 @@ namespace OpenWifi {
 				} break;
 
 				default: {
-					if (SerialNumber_ == "e046ee9fed1f") {
-						// Temporary hack for Galgus device
-						poco_warning(Logger_,
-							fmt::format("FRAME({}): Illegal Frame received (length={}, flags={}). Msg={}",
-										CId_, IncomingSize, flags, IncomingFrame.begin()));
-					}
 					poco_warning(Logger_, fmt::format("UNKNOWN({}): unknown WS Frame operation: {}",
 													  CId_, std::to_string(Op)));
 					Errors_++;

--- a/src/AP_WS_Server.cpp
+++ b/src/AP_WS_Server.cpp
@@ -57,8 +57,9 @@ namespace OpenWifi {
 			if (request.find("Upgrade") != request.end() &&
 				Poco::icompare(request["Upgrade"], "websocket") == 0) {
 				Utils::SetThreadName("ws:conn-init");
-				session_id_++;
-				return new AP_WS_RequestHandler(Logger_, session_id_);
+				//session_id_++;
+				auto new_session_id =  session_id_.fetch_add(1, std::memory_order_seq_cst) + 1;
+				return new AP_WS_RequestHandler(Logger_, new_session_id);
 			} else {
 				return nullptr;
 			}


### PR DESCRIPTION
# Description

Deadlock occurs when large number of APs are connecting/reconnecting to gateway.
More details in: https://telecominfraproject.atlassian.net/browse/WIFI-14499

To fix the issue, early deletion of APs is addressed by this PR.

# Summary of changes:
- Added extra check to prevent early deletion.