### PR TITLE
WIFI-14521: feat: Added processing of clientcas

### DIFF
--- a/src/AP_WS_Server.h
+++ b/src/AP_WS_Server.h
@@ -223,6 +223,7 @@ namespace OpenWifi {
 		mutable std::array<std::mutex,MACHashMax>		SerialNumbersMutex_;
 
 		std::unique_ptr<Poco::Crypto::X509Certificate> IssuerCert_;
+		std::vector<Poco::Crypto::X509Certificate> ClientCasCerts_;
 		std::list<std::unique_ptr<Poco::Net::HTTPServer>> WebServers_;
 		Poco::ThreadPool DeviceConnectionPool_{"ws:dev-pool", 4, 256};
 		Poco::Net::SocketReactor Reactor_;

--- a/src/framework/SubSystemServer.cpp
+++ b/src/framework/SubSystemServer.cpp
@@ -68,6 +68,16 @@ namespace OpenWifi {
 				Context->addCertificateAuthority(Issuing);
 			}
 
+			if (!client_cas_.empty()) {
+				// add certificates specified in clientcas
+				std::vector<Poco::Crypto::X509Certificate> Certs =
+					Poco::Net::X509Certificate::readPEM(client_cas_);
+				for (const auto &cert : Certs) {
+					Context->addChainCertificate(cert);
+					Context->addCertificateAuthority(cert);
+				}
+			}
+
 			Poco::Crypto::RSAKey Key("", key_file_, key_file_password_);
 			Context->usePrivateKey(Key);
 

--- a/src/framework/SubSystemServer.h
+++ b/src/framework/SubSystemServer.h
@@ -45,6 +45,7 @@ namespace OpenWifi {
 		[[nodiscard]] inline auto KeyFile() const { return key_file_; };
 		[[nodiscard]] inline auto CertFile() const { return cert_file_; };
 		[[nodiscard]] inline auto RootCA() const { return root_ca_; };
+		[[nodiscard]] inline auto ClientCas() const { return client_cas_; };
 		[[nodiscard]] inline auto KeyFilePassword() const { return key_file_password_; };
 		[[nodiscard]] inline auto IssuerCertFile() const { return issuer_cert_file_; };
 		[[nodiscard]] inline auto Name() const { return name_; };


### PR DESCRIPTION
# Description
Certificates from `clientcas` need to be used in validation of clients (APs).
More details in: https://telecominfraproject.atlassian.net/browse/WIFI-14521

Summary of changes:
- Updated code to add certificates from clientcas to trust chain and validate client certificates against it.