### PR TITLE
trace: add snaplen and filter parameters

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -587,6 +587,8 @@ Controller sends this command when it needs the device to perform a trace (i.e. 
 	        "packets" : <integer for the number of packets to capture>
 	        "network" : <string identifying the network to trace>
 	        "interface" : <string identifying the interface to capture on>
+	        "snaplen" : Optional - <bytes per packet to capture; defaults to 65535 (full packet). Use 96 for headers only, 512 for headers + small payloads>
+	        "filter" : Optional - <BPF filter expression passed directly to tcpdump, e.g. "host 192.168.1.1 and port 443". Invalid expressions cause tcpdump to exit nonzero and an error is returned via the result channel>
 	        "uri" : <complete URI where to upload the trace. This URI will be available for 30 minutes following a trace request start>
         },
      "id" : <some number>

--- a/openapi/owgw.yaml
+++ b/openapi/owgw.yaml
@@ -753,6 +753,13 @@ components:
           type: string
         interface:
           type: string
+        snaplen:
+          type: integer
+          format: int64
+          description: Bytes per packet to capture. Defaults to 65535 (full packet). Use 96 for headers only.
+        filter:
+          type: string
+          description: BPF filter expression passed to tcpdump, e.g. "host 192.168.1.1 and port 443". Invalid expressions cause tcpdump to exit nonzero and the error is returned via the result channel.
 
     CommandInfo:
       type: object

--- a/src/RESTAPI/RESTAPI_device_commandHandler.cpp
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.cpp
@@ -1235,6 +1235,12 @@ namespace OpenWifi {
 			Params.set(uCentralProtocol::INTERFACE, Interface);
 			Params.set(uCentralProtocol::URI, URI);
 
+			if (Obj->has(RESTAPI::Protocol::SNAPLEN))
+				Params.set(uCentralProtocol::SNAPLEN, Get(RESTAPI::Protocol::SNAPLEN, Obj, 65535));
+
+			if (Obj->has(RESTAPI::Protocol::FILTER))
+				Params.set(uCentralProtocol::FILTER, GetS(RESTAPI::Protocol::FILTER, Obj));
+
 			std::stringstream ParamStream;
 			Params.stringify(ParamStream);
 			Cmd.Details = ParamStream.str();

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -493,6 +493,7 @@ namespace OpenWifi::RESTAPI::Protocol {
 	static const char *PCAP_FILE_TYPE = "pcap";
 	static const char *DURATION = "duration";
 	static const char *NUMBEROFPACKETS = "numberOfPackets";
+	static const char *SNAPLEN = "snaplen";
 	static const char *FILTER = "filter";
 	static const char *SELECT = "select";
 	static const char *SERIALONLY = "serialOnly";
@@ -653,6 +654,8 @@ namespace OpenWifi::uCentralProtocol {
 	static const char *OFF = "off";
 	static const char *BLINK = "blink";
 	static const char *PACKETS = "packets";
+	static const char *SNAPLEN = "snaplen";
+	static const char *FILTER = "filter";
 	static const char *NETWORK = "network";
 	static const char *INTERFACE = "interface";
 	static const char *TRACE = "trace";


### PR DESCRIPTION
## Summary

Adds two optional parameters to the `trace` REST command so operators can capture targeted, small pcap files instead of full interface dumps. Without filters, a 30-second capture produces 33–145 MB files that exceed the default upload limit.

| Field | Type | Default | Description |
|---|---|---|---|
| `snaplen` | integer | 65535 | Bytes per packet captured; passed to `tcpdump -s` |
| `filter` | string | (empty) | BPF expression appended as trailing tcpdump argument |

## Implementation

**`src/framework/ow_constants.h`** — Added constants to both namespaces:
- `RESTAPI::Protocol::SNAPLEN` — reads the new field from the REST request body
- `uCentralProtocol::SNAPLEN` and `uCentralProtocol::FILTER` — keys forwarded to the AP via WebSocket

**`src/RESTAPI/RESTAPI_device_commandHandler.cpp`** — Added two conditionals in `Trace()` after the existing `NETWORK`/`INTERFACE` forwarding:

```cpp
if (Obj->has(RESTAPI::Protocol::SNAPLEN))
    Params.set(uCentralProtocol::SNAPLEN, Get(RESTAPI::Protocol::SNAPLEN, Obj, 65535));

if (Obj->has(RESTAPI::Protocol::FILTER))
    Params.set(uCentralProtocol::FILTER, GetS(RESTAPI::Protocol::FILTER, Obj));
```

No server-side BPF validation is performed — invalid expressions cause tcpdump to exit nonzero on the AP, and the error surfaces through the existing result channel.

**`openapi/owgw.yaml`** — Added `snaplen` and `filter` to the `TraceRequest` schema.

**`PROTOCOL.md`** — Documented both new optional fields under the trace command section.

## Testing

Tested end-to-end against an Aruba AP-325 running OpenWiFi firmware:

```
POST /api/v1/device/3817c3c998ec/trace
{ "duration": 10, "network": "up", "snaplen": 96, "filter": "host 8.8.8.8" }
```

Response `details` confirmed both params forwarded:
```json
{ "duration": 10, "filter": "host 8.8.8.8", "snaplen": 96, ... }
```

Returned pcap had capture length 96 ✓. Traces without the new fields behave identically to before ✓.

The companion AP-side PR is at Telecominfraproject/wlan-ucentral-schema#100 and the UI PR is at Telecominfraproject/wlan-cloud-ucentralgw-ui.